### PR TITLE
replace transchoice by trans

### DIFF
--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -158,7 +158,7 @@
 {% endblock grid_pager %}
 {# ---------------------------------------------------- grid_pager_totalcount -------------------------------------------------- #}
 {% block grid_pager_totalcount %}
-{{ '%count% Results, ' | transchoice(grid.totalCount, {'%count%': grid.totalCount}) }}
+{{ '%count% Results, ' | trans({'%count%': grid.totalCount}) }}
 {% endblock grid_pager_totalcount %}
 {# ---------------------------------------------------- grid_pager_selectpage -------------------------------------------------- #}
 {% block grid_pager_selectpage %}


### PR DESCRIPTION
replace transchoice by trans

transChoice is deprecated since SF4.2 and would fail if not replaced by trans in SF5 (https://symfony.com/blog/new-in-symfony-4-2-intlmessageformatter)

